### PR TITLE
Fix zero-total percentage in ExpenseChart

### DIFF
--- a/src/components/ExpenseChart.tsx
+++ b/src/components/ExpenseChart.tsx
@@ -122,7 +122,8 @@ export default function ExpenseChart({
             </h3>
             <div className="space-y-3 max-h-60 overflow-y-auto pr-2">
               {data.map((category, index) => {
-                const percentage = category.value / totalExpenses;
+                const percentage =
+                  totalExpenses === 0 ? 0 : category.value / totalExpenses;
                 return (
                   <div
                     key={category.id}


### PR DESCRIPTION
## Summary
- guard against zero totals in the expense chart to avoid invalid percentages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444520ca888321964512f13c185374