### PR TITLE
Add Jest and unit tests for format helpers

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -30,6 +31,9 @@
     "eslint-config-next": "14.2.24",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -1,0 +1,59 @@
+import { formatCurrency, formatDate, formatPercentage, truncateText, formatNumber } from '../format';
+
+describe('format utility functions', () => {
+  describe('formatCurrency', () => {
+    it('formats BRL currency by default', () => {
+      expect(formatCurrency(1234.56)).toBe('R$\xa01.234,56');
+    });
+
+    it('respects locale and currency options', () => {
+      expect(formatCurrency(1234.56, { currency: 'USD', locale: 'en-US' })).toBe('$1,234.56');
+    });
+  });
+
+  describe('formatDate', () => {
+    const date = new Date('2023-05-31T00:00:00Z');
+
+    it('formats medium style by default', () => {
+      expect(formatDate(date)).toBe('31 de mai. de 2023');
+    });
+
+    it('supports short format', () => {
+      expect(formatDate(date, { format: 'short' })).toBe('31/05/23');
+    });
+
+    it('supports long format', () => {
+      expect(formatDate(date, { format: 'long' })).toBe('31 de maio de 2023');
+    });
+  });
+
+  describe('formatPercentage', () => {
+    it('formats percentage with defaults', () => {
+      expect(formatPercentage(0.123)).toBe('12,3%');
+    });
+
+    it('allows decimals and no symbol', () => {
+      expect(formatPercentage(0.123, { decimals: 2, includeSymbol: false })).toBe('0,12');
+    });
+  });
+
+  describe('truncateText', () => {
+    it('truncates long text', () => {
+      expect(truncateText('This is a long text that should be truncated', 10)).toBe('This is...');
+    });
+
+    it('returns original when shorter than limit', () => {
+      expect(truncateText('short', 10)).toBe('short');
+    });
+  });
+
+  describe('formatNumber', () => {
+    it('formats number with default decimals', () => {
+      expect(formatNumber(1234.56)).toBe('1.235');
+    });
+
+    it('supports custom decimals', () => {
+      expect(formatNumber(1234.5, { decimals: 2 })).toBe('1.234,50');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest configuration with ts-jest
- provide tests for format helper utilities
- expose `npm test` script

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684445283d748321ad68ca2ca7f87d3b